### PR TITLE
[Week4] 김규민 실버 5문제 제출

### DIFF
--- a/Week2/gyumin/B18511.java
+++ b/Week2/gyumin/B18511.java
@@ -1,0 +1,78 @@
+package gyumin;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class B18511 {
+	static int n;
+	static int k;
+	static int[] pick;
+	static int[] elements;
+	static int res;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		n = Integer.parseInt(st.nextToken());
+		k = Integer.parseInt(st.nextToken());
+		
+		int temp = n;
+		int size = 0;
+		
+		while(temp != 0) {
+			temp /= 10;
+			size++;
+		}
+
+		pick = new int[size];
+		elements = new int[k];
+
+		st = new StringTokenizer(br.readLine());
+
+		for (int i = 0; i < k; i++) {
+			elements[i] = Integer.parseInt(st.nextToken());
+		} // 요소 입력
+
+		select(0);
+		
+		bw.write(res+"");
+		bw.flush();
+		
+		br.close();
+		bw.close();
+
+	} // main
+
+	private static void select(int count) {
+		compare(); // pick.length 는 주어진 자연수로 만들 수 있는 최대 길이일 뿐, 못 채워도 정답일 수 있음
+		
+		if (count >= pick.length) {
+			return;
+		}
+
+		for (int i = 0; i < k; i++) // 중복을 허용하지 않는 문제였다면 (int i = idx; i <= k - pick.length + count; i++), pick.length <= k
+		// 중복을 허용하기 때문에 idx 추적 및 범위 조정 x
+		{
+			pick[count] = elements[i];
+			select(count + 1);
+			pick[count] = 0; // compare() 에서 수를 반환하는 로직에 따라 0으로 초기화
+		}
+	}
+
+	private static void compare() {
+		int temp = 0;
+		for (int i = 0; i < pick.length; i++) {
+			temp += pick[i] * Math.pow(10, i);
+		}
+
+		if (temp > res && temp <= n)
+			res = temp;
+		return;
+	}
+}

--- a/Week2/gyumin/B1992.java
+++ b/Week2/gyumin/B1992.java
@@ -1,0 +1,64 @@
+package gyumin;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+
+public class B1992 {
+	static int[][] quadTree;
+	static StringBuilder sb;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+		int n = Integer.parseInt(br.readLine());
+
+		quadTree = new int[n][];
+
+		for (int i = 0; i < n; i++) {
+			quadTree[i] = Arrays.stream(br.readLine().split("")).mapToInt(Integer::parseInt).toArray();
+		} // 여기서 입력 끝
+
+		sb = new StringBuilder();
+
+		press(0, n, 0, n); // 압축 시작
+		
+		bw.write(sb.toString());
+		bw.flush();
+		
+		br.close();
+		bw.close();
+	}
+
+	private static void press(int rs, int re, int cs, int ce) {
+		int target = quadTree[rs][cs];
+
+		boolean needRecall = false;
+		for (int i = rs; i < re; i++) {
+			for (int j = cs; j < ce; j++) {
+				if (quadTree[i][j] != target) {
+					needRecall = true;
+					break;
+				}
+			}
+			if (needRecall)
+				break;
+		} // 검사 과정
+
+		if (needRecall) {
+			int rowMid = (rs + re) / 2;
+			int colMid = (cs + ce) / 2;
+			sb.append("(");
+			press(rs, rowMid, cs, colMid); // 좌상
+			press(rs, rowMid, colMid, ce); // 우상
+			press(rowMid, re, cs, colMid); // 좌하
+			press(rowMid, re, colMid, ce); // 우하
+			sb.append(")");
+		} else
+			sb.append(target);
+	} // 압축 과정
+}

--- a/Week2/gyumin/B2630.java
+++ b/Week2/gyumin/B2630.java
@@ -1,0 +1,61 @@
+package gyumin;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+
+public class B2630 {
+	static int[] count;
+	static int[][] paper;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+		int n = Integer.parseInt(br.readLine());
+
+		paper = new int[n][];
+		count = new int[2]; // [0]: 하양, [1]: 파랑
+
+		for (int i = 0; i < n; i++) {
+			paper[i] = Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+		} // 여기서 입력 끝
+
+		divide(0, n, 0, n);
+
+		int white = count[0];
+		int blue = count[1];
+
+		bw.write(white + "\n" + blue);
+		bw.flush();
+
+		br.close();
+		bw.close();
+	}
+
+	private static void divide(int rs, int re, int cs, int ce) {
+		int color = paper[rs][cs]; // 여기서 0 이 오면 하양, 1이 오면 파랑인지 검사를 해
+		boolean needRecall = false;
+
+		for (int i = rs; i < re; i++) {
+			for (int j = cs; j < ce; j++) {
+				if (paper[i][j] != color) {
+					needRecall = true;
+				}
+			}
+		} // 검사 완료
+
+		if (needRecall) {
+			int rowMid = (rs + re) / 2;
+			int colMin = (cs + ce) / 2;
+			divide(rs, rowMid, cs, colMin); // 좌상
+			divide(rs, rowMid, colMin, ce); // 우상
+			divide(rowMid, re, cs, colMin); // 좌하
+			divide(rowMid, re, colMin, ce); // 우하
+		} else
+			count[color]++;
+	}
+}

--- a/Week2/gyumin/B4779.java
+++ b/Week2/gyumin/B4779.java
@@ -1,0 +1,58 @@
+package gyumin;
+
+import java.io.*;
+
+public class B4779 {
+	
+	static int length;
+	static char[] kkanpu;
+	
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		
+		String input;
+		while((input = br.readLine()) != null && !input.isEmpty()) {
+			length = (int) Math.pow(3, Integer.parseInt(input));
+			kkanpu = new char[length]; // 3^n 크기의 배열
+			
+			for(int i = 0; i < length; i++) {
+				kkanpu[i] = '-';
+			}
+			
+			impl(0, length);
+			
+			String res = toString(length);
+			bw.write(res+"\n");
+		}
+		
+		bw.flush();
+		
+		br.close();
+		bw.close();
+	}
+
+	private static String toString(int l) {
+		StringBuffer sb = new StringBuffer();
+		
+		for(int i = 0; i < l; i++) {
+			sb.append(kkanpu[i]);
+		}
+		
+		return sb.toString();
+	}
+
+	private static void impl(int s, int l) {
+		if(l <= 1 || l > length) return;
+		
+		int sub = l / 3;
+		
+		for(int i = sub + s; i < (sub * 2) + s; i++) {
+			kkanpu[i] = ' ';
+		}// 두번째 묶음(중간) 공백 처리
+		
+		impl(s, sub); // 첫 묶음 처리
+		impl(s + sub * 2, sub); // 세번째 묶음 처리
+	}
+	
+}

--- a/Week2/gyumin/B9184.java
+++ b/Week2/gyumin/B9184.java
@@ -1,0 +1,65 @@
+package gyumin;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class B9184 {
+	// a, b, c 의 값을 인덱스 삼아서 3차원 배열에 저장하는 방식으로 메모이제이션 구현
+	// 어차피 21 이상의 값이 들어오면 20으로 줄여버림
+	static int[][][] memory = new int[21][21][21];
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringBuilder sb = new StringBuilder();
+
+		int[] input = new int[3];
+
+		while (true) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+
+			for (int i = 97; i < 100; i++) {
+				input[i - 'a'] = Integer.parseInt(st.nextToken());
+			} // 입력
+
+			if (input['a' - 'a'] == -1 && input['b' - 'a'] == -1 && input['c' - 'a'] == -1)
+				break; // 셋 다 -1이면 종료
+
+			int res = w(input['a' - 'a'], input['b' - 'a'], input['c' - 'a']);
+
+			sb.append(String.format("w(%d, %d, %d) = %d\n", input['a' - 'a'], input['b' - 'a'], input['c' - 'a'], res));
+		}
+
+		bw.write(sb.toString());
+		bw.flush();
+
+		br.close();
+		bw.close();
+	} // main
+
+	private static int w(int a, int b, int c) {
+		if (a <= 0 || b <= 0 || c <= 0)
+			return 1;
+
+		if (a > 20 || b > 20 || c > 20) {
+			if (memory[20][20][20] == 0)
+				memory[20][20][20] = w(20, 20, 20);
+			return memory[20][20][20];
+		}
+
+		if (memory[a][b][c] != 0)
+			return memory[a][b][c]; // 저장한 값이 있으면 바로 리턴
+
+		if (a < b && b < c) {
+			memory[a][b][c] = w(a, b, c - 1) + w(a, b - 1, c - 1) - w(a, b - 1, c);
+			return memory[a][b][c];
+		}
+
+		return memory[a][b][c] = w(a - 1, b, c) + w(a - 1, b - 1, c) + w(a - 1, b, c - 1) - w(a - 1, b - 1, c - 1);
+
+	} // w
+}


### PR DESCRIPTION
## Week 4 문제 목록
이번 주는 알고리즘 스터디의 네 번째 주차입니다. 지난 회차에 해결하지 못했던 알고리즘 문제를 해결해 봅시다.

### 실버 문제
1.2630 - 색종이 만들기

주어진 정사각형 종이를 같은 색이 될 때까지 분할하는 문제입니다.
2. 1992 - 쿼드트리

흑백 영상을 압축하여 표현하는 방법인 쿼드 트리를 구현하는 문제입니다.

*위 두 문제는 출력 형식만 다를 뿐 각 사분면을 나누어 재귀호출을 한다는 점에서 유사한 문제*

3. 9184 - 신나는 함수 실행

메모이제이션을 이용한 재귀 함수를 최적화하는 문제입니다.
a, b, c 를 각각 인덱스로 처리해 3차원 배열에 메모이제이션 하여 풀었습니다.
4. 4779 - 칸토어 집합

칸토어 집합을 재귀적으로 구현하여 출력하는 문제입니다.
깐푸어 집합은 가운데를 날리고 첫 묶음과 세번째 묶음을 어떻게 지정할 지 고민하면서 풀었습니다.
5. 18511 - 큰 수 구성하기

주어진 숫자 집합을 이용해 만들 수 있는 가장 큰 수를 찾는 문제입니다.
주어진 숫자가 3자리 수라고 반드시 정답이 3자리 수 라는 보장이 없다는 것과 집합 크기가 아닌 주어진 숫자의 자리수가 최대 뽑을 수 있는 개수라는 점에 유의하여 풀었습니다.